### PR TITLE
Request creation and testing support

### DIFF
--- a/src/main/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModule.java
+++ b/src/main/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModule.java
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Component;
  * Locates a policy in ModeShape by evaluation context or by URI.
  * @author Gregory Jansen
  */
-@Component
+@Component("fedoraPolicyFinderModule")
 public class FedoraPolicyFinderModule extends PolicyFinderModule {
 
     /*

--- a/src/main/java/org/fcrepo/auth/xacml/FedoraResourceFinderModule.java
+++ b/src/main/java/org/fcrepo/auth/xacml/FedoraResourceFinderModule.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
  * Locates resources that are subordinate to a Fedora resource.
  * @author Gregory Jansen
  */
-@Component
+@Component("fedoraResourceFinderModule")
 public class FedoraResourceFinderModule extends ResourceFinderModule {
 
     /*

--- a/src/main/java/org/fcrepo/auth/xacml/PDPFactoryBean.java
+++ b/src/main/java/org/fcrepo/auth/xacml/PDPFactoryBean.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.xacml;
+
+import java.util.Collections;
+
+import org.jboss.security.xacml.sunxacml.PDP;
+import org.jboss.security.xacml.sunxacml.PDPConfig;
+import org.jboss.security.xacml.sunxacml.finder.AttributeFinder;
+import org.jboss.security.xacml.sunxacml.finder.PolicyFinder;
+import org.jboss.security.xacml.sunxacml.finder.ResourceFinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Factory that creates the XACML Policy Decision Point.
+ *
+ * @author Gregory Jansen
+ */
+public class PDPFactoryBean {
+
+    /**
+     * Creates the factory.
+     */
+    public PDPFactoryBean() {
+    }
+
+    /**
+     * Class logger.
+     */
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(PDPFactoryBean.class);
+
+    /**
+     * Make a PDP for the Fedora environment.
+     *
+     * @see org.springframework.beans.factory.FactoryBean#getObject()
+     * @param fedoraPolicyFinderModule policy finder module
+     * @param fedoraResourceFinderModule resource finder module
+     * @return the PDP
+     */
+    public final PDP makePDP(
+            final FedoraPolicyFinderModule fedoraPolicyFinderModule,
+            final FedoraResourceFinderModule fedoraResourceFinderModule) {
+        final PolicyFinder policyFinder = new PolicyFinder();
+        policyFinder
+                .setModules(Collections.singleton(fedoraPolicyFinderModule));
+        final ResourceFinder resourceFinder = new ResourceFinder();
+        resourceFinder.setModules(Collections
+                .singletonList(fedoraResourceFinderModule));
+        final PDPConfig pdpConfig =
+                new PDPConfig(new AttributeFinder(), policyFinder,
+                        resourceFinder);
+        final PDP pdp = new PDP(pdpConfig);
+        LOGGER.info("XACML Policy Decision Point (PDP) initialized");
+        return pdp;
+    }
+
+}

--- a/src/main/java/org/fcrepo/auth/xacml/URIConstants.java
+++ b/src/main/java/org/fcrepo/auth/xacml/URIConstants.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.xacml;
+
+import java.net.URI;
+
+import org.jboss.security.xacml.interfaces.XACMLConstants;
+
+
+/**
+ * URIs that are used in this module.
+ *
+ * @author Gregory Jansen
+ */
+public abstract class URIConstants {
+
+    /**
+     * ID of the subject (user principal).
+     */
+    public static final URI ATTRIBUTEID_SUBJECT_ID = URI
+            .create(XACMLConstants.ATTRIBUTEID_SUBJECT_ID);
+
+    /**
+     * ID of the action (ModeShape permission name).
+     */
+    public static final URI ATTRIBUTEID_ACTION_ID = URI
+            .create(XACMLConstants.ATTRIBUTEID_ACTION_ID);
+
+    /**
+     * ID of the resource (ModeShape node/property path).
+     */
+    public static final URI ATTRIBUTEID_RESOURCE_ID = URI
+            .create(XACMLConstants.ATTRIBUTEID_RESOURCE_ID);
+
+    /**
+     * ID of the ModeShape workspace for this resource.
+     */
+    public static final URI ATTRIBUTEID_RESOURCE_WORKSPACE = URI
+            .create("urn:fedora:xacml:2.0:resource:resource-workspace");
+
+    /**
+     * Scope of the request (DESCENDANTS if "remove", IMMEDIATE otherwise).
+     */
+    public static final URI ATTRIBUTEID_RESOURCE_SCOPE = URI
+            .create("urn:oasis:names:tc:xacml:1.0:resource:scope");
+
+}

--- a/src/test/java/org/fcrepo/integration/auth/xacml/SpringContextIT.java
+++ b/src/test/java/org/fcrepo/integration/auth/xacml/SpringContextIT.java
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.auth.xacml;
+
+package org.fcrepo.integration.auth.xacml;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/resources/spring-test/repo.xml
+++ b/src/test/resources/spring-test/repo.xml
@@ -6,7 +6,6 @@
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
   <!-- Context that supports the actual ModeShape JCR itself -->
-
   <context:annotation-config />
 
   <context:component-scan base-package="org.fcrepo.kernel.services" />
@@ -20,6 +19,13 @@
   <bean name="authenticationProvider" class="org.fcrepo.auth.common.ServletContainerAuthenticationProvider">
     <property name="fad" ref="fad"/>
   </bean>
+
+  <bean name="pdp" class="org.jboss.security.xacml.sunxacml.PDP" factory-bean="pdpFactory" factory-method="makePDP">
+    <constructor-arg ref="fedoraPolicyFinderModule"/>
+    <constructor-arg ref="fedoraResourceFinderModule"/>
+  </bean>
+
+  <bean name="pdpFactory" class="org.fcrepo.auth.xacml.PDPFactoryBean"/>
 
   <bean class="org.modeshape.jcr.JcrRepositoryFactory" />
 


### PR DESCRIPTION
PDP creation moved to factory to support injected mocks
request and eval contexts are created from modeshape data.
component names added to certain finders to support wiring in XML
