### PR TITLE
story 81846720. Fix fcrepo-module-auth-rbacl/xacml.

### DIFF
--- a/src/main/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModule.java
+++ b/src/main/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModule.java
@@ -30,8 +30,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.fcrepo.http.commons.session.SessionFactory;
 import org.fcrepo.jcr.FedoraJcrTypes;
-import org.fcrepo.kernel.FedoraBinary;
-import org.fcrepo.kernel.FedoraResource;
+import org.fcrepo.kernel.models.FedoraBinary;
+import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.services.BinaryService;
 import org.fcrepo.kernel.services.NodeService;
@@ -185,9 +185,9 @@ public class FedoraPolicyFinderModule extends PolicyFinderModule {
             final Property prop = nodeWithPolicy.getProperty(XACML_POLICY_PROPERTY);
 
             final FedoraBinary policyBinary;
-            final FedoraResource resource = nodeService.getObject(internalSession, prop.getNode().getPath());
-            if (resource.hasType(FedoraJcrTypes.FEDORA_DATASTREAM)) {
-                policyBinary = binaryService.findOrCreateBinary(internalSession, resource.getNode().getPath());
+            final FedoraResource resource = nodeService.find(internalSession, prop.getNode().getPath());
+            if (resource.hasType(FedoraJcrTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION)) {
+                policyBinary = binaryService.findOrCreate(internalSession, resource.getNode().getPath());
 
             } else {
                 LOGGER.warn("Policy Binary not found for: {}", path);
@@ -244,9 +244,9 @@ public class FedoraPolicyFinderModule extends PolicyFinderModule {
             final Session internalSession = sessionFactory.getInternalSession();
 
             final FedoraBinary policyBinary;
-            final FedoraResource resource = nodeService.getObject(internalSession, path);
-            if (resource.hasType(FedoraJcrTypes.FEDORA_DATASTREAM)) {
-                policyBinary = binaryService.findOrCreateBinary(internalSession, resource.getNode().getPath());
+            final FedoraResource resource = nodeService.find(internalSession, path);
+            if (resource.hasType(FedoraJcrTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION)) {
+                policyBinary = binaryService.findOrCreate(internalSession, resource.getNode().getPath());
 
             } else {
                 LOGGER.warn("Policy Binary not found for: {}", path);

--- a/src/main/java/org/fcrepo/auth/xacml/TripleAttributeFinderModule.java
+++ b/src/main/java/org/fcrepo/auth/xacml/TripleAttributeFinderModule.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import javax.jcr.Session;
 
 import org.fcrepo.http.commons.session.SessionFactory;
-import org.fcrepo.kernel.FedoraResource;
+import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.impl.rdf.impl.PropertiesRdfContext;
@@ -171,7 +171,7 @@ public class TripleAttributeFinderModule extends AttributeFinderModule {
         final FedoraResource resource;
         final String path;
         try {
-            resource = nodeService.getObject(session, resourceId);
+            resource = nodeService.find(session, resourceId);
             if (resource == null) {
                 LOGGER.debug("Cannot find a fedora resource for {}", resourceId);
                 return new EvaluationResult(empty_bag);

--- a/src/main/java/org/fcrepo/auth/xacml/XACMLWorkspaceInitializer.java
+++ b/src/main/java/org/fcrepo/auth/xacml/XACMLWorkspaceInitializer.java
@@ -27,16 +27,18 @@ import javax.jcr.nodetype.NodeType;
 import javax.jcr.nodetype.NodeTypeIterator;
 import javax.jcr.nodetype.NodeTypeTemplate;
 
-import com.google.common.collect.ImmutableList;
-import org.apache.commons.io.FileUtils;
 import org.fcrepo.http.commons.session.SessionFactory;
-import org.fcrepo.kernel.FedoraBinary;
 import org.fcrepo.kernel.exception.InvalidChecksumException;
+import org.fcrepo.kernel.models.FedoraBinary;
 import org.fcrepo.kernel.services.BinaryService;
+
+import org.apache.commons.io.FileUtils;
 import org.modeshape.jcr.api.nodetype.NodeTypeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * Sets up node types and default policies for the XACML Authorization Delegate.
@@ -121,8 +123,8 @@ public class XACMLWorkspaceInitializer {
                 LOGGER.debug("registered node type: {}", nt.getName());
             }
 
-            // Add "authz:xacmlAssignable" mixin to "fedora:resource" type
-            final NodeType nodeType = mgr.getNodeType("fedora:resource");
+            // Add "authz:xacmlAssignable" mixin to "fedora:Resource" type
+            final NodeType nodeType = mgr.getNodeType("fedora:Resource");
             final NodeTypeTemplate nodeTypeTemplate = mgr.createNodeTypeTemplate(nodeType);
             final String[] superTypes = nodeType.getDeclaredSupertypeNames();
             final ImmutableList.Builder<String> listBuilder = ImmutableList.builder();
@@ -154,7 +156,7 @@ public class XACMLWorkspaceInitializer {
             for (final File p : initialPoliciesDirectory.listFiles()) {
                 final String id = PolicyUtil.getID(FileUtils.openInputStream(p));
                 final String repoPath = PolicyUtil.getPathForId(id);
-                final FedoraBinary binary = binaryService.findOrCreateBinary(session, repoPath);
+                final FedoraBinary binary = binaryService.findOrCreate(session, repoPath);
                 binary.setContent(new FileInputStream(p),
                                   "application/xml",
                                   null,

--- a/src/main/resources/cnd/xacml-policy.cnd
+++ b/src/main/resources/cnd/xacml-policy.cnd
@@ -4,4 +4,4 @@
 [authz:xacmlAssignable] mixin
  - authz:policy (REFERENCE)
 
-[authz:xacmlPolicy] > fedora:datastream mixin
+[authz:xacmlPolicy] > fedora:NonRdfSourceDescription mixin

--- a/src/test/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModuleTest.java
+++ b/src/test/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModuleTest.java
@@ -40,8 +40,8 @@ import javax.jcr.Session;
 
 import org.fcrepo.http.commons.session.SessionFactory;
 import org.fcrepo.jcr.FedoraJcrTypes;
-import org.fcrepo.kernel.Datastream;
-import org.fcrepo.kernel.FedoraBinary;
+import org.fcrepo.kernel.models.NonRdfSourceDescription;
+import org.fcrepo.kernel.models.FedoraBinary;
 import org.fcrepo.kernel.services.BinaryService;
 import org.fcrepo.kernel.services.NodeService;
 import org.jboss.security.xacml.sunxacml.EvaluationCtx;
@@ -80,10 +80,10 @@ public class FedoraPolicyFinderModuleTest {
     private Node mockPolicyNode;
 
     @Mock
-    private Datastream mockPolicyDs;
+    private NonRdfSourceDescription mockPolicyDs;
 
     @Mock
-    private Datastream mockResource;
+    private NonRdfSourceDescription mockResource;
 
     @Mock
     private FedoraBinary mockBinary;
@@ -122,13 +122,13 @@ public class FedoraPolicyFinderModuleTest {
 
         when(mockPolicyProperty.getNode()).thenReturn(mockPolicyNode);
 
-        when(mockNodeService.getObject(any(Session.class), anyString())).thenReturn(mockResource);
-        when(mockResource.hasType(FedoraJcrTypes.FEDORA_DATASTREAM)).thenReturn(true);
-        when(mockResource.getBinary()).thenReturn(mockBinary);
+        when(mockNodeService.find(any(Session.class), anyString())).thenReturn(mockResource);
+        when(mockResource.hasType(FedoraJcrTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION)).thenReturn(true);
+        when(mockResource.getDescribedResource()).thenReturn(mockBinary);
 
         when(mockResource.getNode()).thenReturn(mockNode);
         when(mockNode.getPath()).thenReturn("/{}myPath");
-        when(mockBinaryService.findOrCreateBinary(any(Session.class), anyString())).thenReturn(mockBinary);
+        when(mockBinaryService.findOrCreate(any(Session.class), anyString())).thenReturn(mockBinary);
 
         finderModule = new FedoraPolicyFinderModule();
         setField(finderModule, "sessionFactory", mockSessionFactory);
@@ -153,7 +153,7 @@ public class FedoraPolicyFinderModuleTest {
         when(mockNode.hasProperty(eq(XACML_POLICY_PROPERTY))).thenReturn(true);
         when(mockNode.getProperty(eq(XACML_POLICY_PROPERTY))).thenReturn(mockPolicyProperty);
 
-        when(mockPolicyDs.getBinary()).thenReturn(mockBinary);
+        when(mockPolicyDs.getDescribedResource()).thenReturn(mockBinary);
         when(mockBinary.getContent()).thenReturn(this.getClass().getResourceAsStream("/xacml/testPolicy.xml"));
 
         final FedoraEvaluationCtxBuilder ctxBuilder = new FedoraEvaluationCtxBuilder();
@@ -176,7 +176,7 @@ public class FedoraPolicyFinderModuleTest {
         final String idPath = POLICY_URI_PREFIX + policyPath;
         final URI idReference = new URI(idPath);
 
-        when(mockPolicyDs.getBinary()).thenReturn(mockBinary);
+        when(mockPolicyDs.getDescribedResource()).thenReturn(mockBinary);
         when(mockBinary.getContent()).thenReturn(this.getClass().getResourceAsStream("/xacml/testPolicy.xml"));
 
         final PolicyFinderResult result = finderModule.findPolicy(idReference, 0, null, null);
@@ -192,14 +192,14 @@ public class FedoraPolicyFinderModuleTest {
         when(mockNode.hasProperty(eq(XACML_POLICY_PROPERTY))).thenReturn(true);
         when(mockNode.getProperty(eq(XACML_POLICY_PROPERTY))).thenReturn(mockPolicyProperty);
 
-        when(mockPolicyDs.getBinary()).thenReturn(mockBinary);
+        when(mockPolicyDs.getDescribedResource()).thenReturn(mockBinary);
         when(mockBinary.getContent())
         .thenReturn(this.getClass().getResourceAsStream("/xacml/adminRolePolicySet.xml"));
 
         final String referencedId = "fcrepo:policies/AdminPermissionPolicySet";
-        final Datastream referencedPolicyDs = mock(Datastream.class);
+        final NonRdfSourceDescription referencedPolicyDs = mock(NonRdfSourceDescription.class);
         final FedoraBinary referencedPolicyBinary = mock(FedoraBinary.class);
-        when(referencedPolicyDs.getBinary()).thenReturn(referencedPolicyBinary);
+        when(referencedPolicyDs.getDescribedResource()).thenReturn(referencedPolicyBinary);
         when(referencedPolicyBinary.getContent()).thenReturn(
                 this.getClass().getResourceAsStream("/xacml/adminPermissionPolicySet.xml"));
 

--- a/src/test/java/org/fcrepo/auth/xacml/TripleAttributeFinderModuleTest.java
+++ b/src/test/java/org/fcrepo/auth/xacml/TripleAttributeFinderModuleTest.java
@@ -35,7 +35,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import org.fcrepo.http.commons.session.SessionFactory;
-import org.fcrepo.kernel.FedoraResource;
+import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.impl.rdf.impl.PropertiesRdfContext;
@@ -164,7 +164,7 @@ public class TripleAttributeFinderModuleTest {
 
         final String resourceId = "/{ns}path/{ns}to/{ns}resource";
 
-        when(mockNodeService.getObject(mockSession, resourceId)).thenReturn(mockFedoraResource);
+        when(mockNodeService.find(mockSession, resourceId)).thenReturn(mockFedoraResource);
         when(mockFedoraResource.getTriples(any(IdentifierConverter.class), eq(PropertiesRdfContext.class))).thenReturn(
                 mockRdfStream);
         when(mockIdentifierTranslator.reverse()).thenReturn(mockIdentifierTranslator);
@@ -212,7 +212,7 @@ public class TripleAttributeFinderModuleTest {
     public void testFindAttributeEmptyResourceId() throws RepositoryException {
         final String resourceId = "";
 
-        when(mockNodeService.getObject(mockSession, resourceId)).thenReturn(null);
+        when(mockNodeService.find(mockSession, resourceId)).thenReturn(null);
 
         final EvaluationResult result = doFindAttribute(resourceId);
         final String status = (String) result.getStatus().getCode().get(0);
@@ -225,7 +225,7 @@ public class TripleAttributeFinderModuleTest {
         final String resourceId = "/{ns}no/{ns}such/{ns}path";
         final String[] actions = { "read" };
 
-        when(mockNodeService.getObject(mockSession, resourceId)).thenReturn(null);
+        when(mockNodeService.find(mockSession, resourceId)).thenReturn(null);
 
         final EvaluationResult result = doFindAttribute(resourceId, actions);
         final BagAttribute bag = (BagAttribute) result.getAttributeValue();
@@ -238,7 +238,7 @@ public class TripleAttributeFinderModuleTest {
         final String resourceId = "/{ns}no/{ns}such{ns}/path";
         final String[] actions = { "read" };
 
-        when(mockNodeService.getObject(mockSession, resourceId)).thenReturn(mockFedoraResource);
+        when(mockNodeService.find(mockSession, resourceId)).thenReturn(mockFedoraResource);
         when(mockFedoraResource.getPath()).thenThrow(new RepositoryRuntimeException("expected"));
 
         final EvaluationResult result = doFindAttribute(resourceId, actions);
@@ -255,7 +255,7 @@ public class TripleAttributeFinderModuleTest {
         final ArgumentCaptor<String> propResourceId = ArgumentCaptor.forClass(String.class);
 
         doFindAttribute(resourceId, actions);
-        verify(mockNodeService).getObject(any(Session.class), propResourceId.capture());
+        verify(mockNodeService).find(any(Session.class), propResourceId.capture());
         assertEquals("/{ns}path/{ns}to/{ns}node", propResourceId.getValue());
     }
 
@@ -267,7 +267,7 @@ public class TripleAttributeFinderModuleTest {
         final ArgumentCaptor<String> propResourceId = ArgumentCaptor.forClass(String.class);
 
         doFindAttribute(resourceId, actions);
-        verify(mockNodeService).getObject(any(Session.class), propResourceId.capture());
+        verify(mockNodeService).find(any(Session.class), propResourceId.capture());
         assertEquals("/{ns}path/{ns}to/{ns}node", propResourceId.getValue());
     }
 
@@ -279,7 +279,7 @@ public class TripleAttributeFinderModuleTest {
         final ArgumentCaptor<String> propResourceId = ArgumentCaptor.forClass(String.class);
 
         doFindAttribute(resourceId, actions);
-        verify(mockNodeService).getObject(any(Session.class), propResourceId.capture());
+        verify(mockNodeService).find(any(Session.class), propResourceId.capture());
         assertEquals("/", propResourceId.getValue());
     }
 
@@ -291,7 +291,7 @@ public class TripleAttributeFinderModuleTest {
         final ArgumentCaptor<String> propResourceId = ArgumentCaptor.forClass(String.class);
 
         doFindAttribute(resourceId, actions);
-        verify(mockNodeService).getObject(any(Session.class), propResourceId.capture());
+        verify(mockNodeService).find(any(Session.class), propResourceId.capture());
         assertEquals("/", propResourceId.getValue());
     }
 
@@ -300,7 +300,7 @@ public class TripleAttributeFinderModuleTest {
         final String resourceId = "/{ns}no/{ns}such/{ns}path";
         final String[] actions = { "read" };
 
-        when(mockNodeService.getObject(mockSession, resourceId)).thenReturn(mockFedoraResource);
+        when(mockNodeService.find(mockSession, resourceId)).thenReturn(mockFedoraResource);
         when(mockFedoraResource.getTriples(any(IdentifierConverter.class), eq(PropertiesRdfContext.class))).thenThrow(
                 new RepositoryRuntimeException("expected"));
 

--- a/src/test/java/org/fcrepo/auth/xacml/XACMLWorkspaceInitializerTest.java
+++ b/src/test/java/org/fcrepo/auth/xacml/XACMLWorkspaceInitializerTest.java
@@ -32,8 +32,8 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import org.fcrepo.http.commons.session.SessionFactory;
-import org.fcrepo.kernel.Datastream;
-import org.fcrepo.kernel.FedoraBinary;
+import org.fcrepo.kernel.models.NonRdfSourceDescription;
+import org.fcrepo.kernel.models.FedoraBinary;
 import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 
 import org.fcrepo.kernel.services.BinaryService;
@@ -65,7 +65,7 @@ public class XACMLWorkspaceInitializerTest {
     private BinaryService mockBinaryService;
 
     @Mock
-    Datastream mockDatastream;
+    NonRdfSourceDescription mockNonRdfSourceDescription;
 
     @Mock
     FedoraBinary mockBinary;
@@ -76,8 +76,8 @@ public class XACMLWorkspaceInitializerTest {
 
         when(mockSessionFactory.getInternalSession()).thenReturn(mockSession);
         when(mockSession.getRootNode()).thenReturn(mockNode);
-        when(mockBinaryService.findOrCreateBinary(eq(mockSession), anyString())).thenReturn(mockBinary);
-        when(mockDatastream.getPath()).thenReturn("/dummy/test/path");
+        when(mockBinaryService.findOrCreate(eq(mockSession), anyString())).thenReturn(mockBinary);
+        when(mockNonRdfSourceDescription.getPath()).thenReturn("/dummy/test/path");
 
         final File initialPoliciesDirectory = policiesDirectory();
         final File initialRootPolicyFile = rootPolicyFile();
@@ -118,12 +118,12 @@ public class XACMLWorkspaceInitializerTest {
 
     @Test
     public void testInit() throws Exception {
-        when(mockBinaryService.findOrCreateBinary(eq(mockSession), anyString())).thenReturn(mockBinary);
+        when(mockBinaryService.findOrCreate(eq(mockSession), anyString())).thenReturn(mockBinary);
 
         xacmlWI.init();
 
         final int expectedFiles = policiesDirectory().list().length;
-        verify(mockBinaryService, times(expectedFiles)).findOrCreateBinary(eq(mockSession), anyString());
+        verify(mockBinaryService, times(expectedFiles)).findOrCreate(eq(mockSession), anyString());
 
         verify(mockNode).addMixin("authz:xacmlAssignable");
         verify(mockNode).setProperty(eq("authz:policy"), any(Node.class));
@@ -138,7 +138,7 @@ public class XACMLWorkspaceInitializerTest {
 
     @Test(expected = Error.class)
     public void testInitLinkRootToPolicyException() throws Exception {
-        when(mockBinaryService.findOrCreateBinary(eq(mockSession), anyString())).thenReturn(mockBinary);
+        when(mockBinaryService.findOrCreate(eq(mockSession), anyString())).thenReturn(mockBinary);
         when(mockSession.getRootNode()).thenThrow(new RepositoryException("expected"));
 
         xacmlWI.init();


### PR DESCRIPTION
Updated rbacl module in accordance to fedora model object renames and package changes. (https://github.com/fcrepo4/fcrepo4/commit/9b6bd6f5bbcfb045a4f7fd9a7e0536efb3bb6126)

https://www.pivotaltracker.com/story/show/81846720
