### PR TITLE
normalized configuration values

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,10 +7,10 @@
         </encoder>
     </appender>
 
-	<logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+	<logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
         <appender-ref ref="STDOUT"/>
     </logger>
-    <logger name="org.fcrepo.auth" additivity="false" level="${log.fcrepo.auth:-INFO}">
+    <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-INFO}">
         <appender-ref ref="STDOUT"/>
     </logger>
     <root additivity="false" level="WARN">

--- a/src/test/resources/repository.json
+++ b/src/test/resources/repository.json
@@ -8,10 +8,10 @@
     },
     "storage" : {
         "cacheName" : "FedoraRepository",
-        "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/infinispan/leveldb-default/infinispan.xml}",
+        "cacheConfiguration" : "${fcrepo.ispn.configuration:config/infinispan/leveldb-default/infinispan.xml}",
         "binaryStorage" : {
             "type" : "file",
-            "directory" : "${fcrepo.binary-store-path:target/binaries}",
+            "directory" : "${fcrepo.binary.directory:target/binaries}",
             "minimumBinarySizeInBytes" : 4096
         }
     },

--- a/src/test/resources/spring-test/repo.xml
+++ b/src/test/resources/spring-test/repo.xml
@@ -22,7 +22,7 @@
     <bean class="org.modeshape.jcr.ModeShapeEngine" init-method="start"/>
   
   <bean class="org.fcrepo.auth.xacml.XACMLWorkspaceInitializer" init-method="initTest">
-    <constructor-arg value="${fcrepo.xacml.initial.policies.dir:src/main/resources/policies}"/>
+    <constructor-arg value="${fcrepo.xacml.initial.policies.directory:src/main/resources/policies}"/>
     <constructor-arg value="${fcrepo.xacml.initial.root.policy.file:src/main/resources/policies/GlobalRolesPolicySet.xml}"/>
   </bean>
 


### PR DESCRIPTION
See also https://jira.duraspace.org/browse/FCREPO-1288

This leaves one value unchanged: `test.port`

I am not entirely sure why the tests fail when this value is set to fcrepo.test.port, but it does. Otherwise, the other configuration values have been updated.