### PR TITLE
Rename dynamic build properties for clarity

### DIFF
--- a/src/test/resources/spring-test/test-container.xml
+++ b/src/test/resources/spring-test/test-container.xml
@@ -13,7 +13,7 @@
   </bean>
   
   <bean id="containerWrapper" class="org.fcrepo.http.commons.test.util.ContainerWrapper" init-method="start" destroy-method="stop" >
-    <property name="port" value="${fcrepo.test.port:8080}"/>
+    <property name="port" value="${fcrepo.dynamic.test.port:8080}"/>
     <property name="configLocation" value="classpath:web.xml" />
   </bean>
   


### PR DESCRIPTION
The build-helper-maven-plugin is used to generate properties for dynamic
port configuration. This commit marks these properties with the word
`dynamic` to highlight that fact, e.g. `fcrepo.dynamic.test.port`.