### PR TITLE
Follow-on to removing jcr.Session from the kernel-api

### DIFF
--- a/src/main/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModule.java
+++ b/src/main/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModule.java
@@ -19,6 +19,7 @@ package org.fcrepo.auth.xacml;
 
 import static org.fcrepo.auth.xacml.URIConstants.POLICY_URI_PREFIX;
 import static org.fcrepo.auth.xacml.URIConstants.XACML_POLICY_PROPERTY;
+import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.net.URI;
@@ -27,11 +28,11 @@ import javax.inject.Inject;
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -169,10 +170,10 @@ public class FedoraPolicyFinderModule extends PolicyFinderModule {
         }
 
         try {
-            final Session internalSession = sessionFactory.getInternalSession();
+            final FedoraSession internalSession = sessionFactory.getInternalSession();
 
             // Walk up the hierarchy to find the first node with a policy assigned
-            Node nodeWithPolicy = PolicyUtil.getFirstRealNode(path, internalSession);
+            Node nodeWithPolicy = PolicyUtil.getFirstRealNode(path, getJcrSession(internalSession));
             while (nodeWithPolicy != null && !nodeWithPolicy.hasProperty(XACML_POLICY_PROPERTY)) {
                 nodeWithPolicy = nodeWithPolicy.getParent();
             }
@@ -241,7 +242,7 @@ public class FedoraPolicyFinderModule extends PolicyFinderModule {
         }
 
         final String path = PolicyUtil.getPathForId(id);
-        final Session internalSession = sessionFactory.getInternalSession();
+        final FedoraSession internalSession = sessionFactory.getInternalSession();
 
         final FedoraBinary policyBinary;
         final FedoraResource resource = nodeService.find(internalSession, path);

--- a/src/main/java/org/fcrepo/auth/xacml/FedoraResourceFinderModule.java
+++ b/src/main/java/org/fcrepo/auth/xacml/FedoraResourceFinderModule.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.auth.xacml;
 
+import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isInternalNode;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.jboss.security.xacml.sunxacml.ctx.Status.STATUS_PROCESSING_ERROR;
@@ -29,9 +30,9 @@ import javax.inject.Inject;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.FedoraSession;
 
 import org.jboss.security.xacml.sunxacml.EvaluationCtx;
 import org.jboss.security.xacml.sunxacml.attr.AttributeValue;
@@ -110,8 +111,8 @@ public class FedoraResourceFinderModule extends ResourceFinderModule {
     **/
     private ResourceFinderResult findChildren( final AttributeValue parent, final boolean recurse ) {
         try {
-            final Session session = sessionFactory.getInternalSession();
-            final Node node = session.getNode( parent.getValue().toString() );
+            final FedoraSession session = sessionFactory.getInternalSession();
+            final Node node = getJcrSession(session).getNode( parent.getValue().toString() );
             final Set<String> children = new HashSet<>();
             findChildren( node, children, recurse );
             return new ResourceFinderResult( children );

--- a/src/main/java/org/fcrepo/auth/xacml/TripleAttributeFinderModule.java
+++ b/src/main/java/org/fcrepo/auth/xacml/TripleAttributeFinderModule.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableSet;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
+import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.jboss.security.xacml.sunxacml.attr.AttributeDesignator.RESOURCE_TARGET;
 import static org.jboss.security.xacml.sunxacml.attr.BagAttribute.createEmptyBag;
 import static org.jboss.security.xacml.sunxacml.ctx.Status.STATUS_PROCESSING_ERROR;
@@ -32,10 +33,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import javax.jcr.Session;
 import javax.inject.Inject;
 
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -134,7 +135,7 @@ public class TripleAttributeFinderModule extends AttributeFinderModule {
             return new EvaluationResult(empty_bag);
         }
 
-        final Session session;
+        final FedoraSession session;
         try {
             session = sessionFactory.getInternalSession();
         } catch (final RepositoryRuntimeException e) {
@@ -179,7 +180,7 @@ public class TripleAttributeFinderModule extends AttributeFinderModule {
                 return new EvaluationResult(empty_bag);
             }
             path = resource.getPath();
-            idTranslator = new DefaultIdentifierTranslator(session);
+            idTranslator = new DefaultIdentifierTranslator(getJcrSession(session));
 
         } catch (final RepositoryRuntimeException e) {
             // If the object does not exist, it may be due to the action being "create"

--- a/src/test/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModuleTest.java
+++ b/src/test/java/org/fcrepo/auth/xacml/FedoraPolicyFinderModuleTest.java
@@ -42,11 +42,13 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.NodeService;
+import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 import org.fcrepo.kernel.modeshape.NonRdfSourceDescriptionImpl;
 
 import org.jboss.security.xacml.sunxacml.EvaluationCtx;
@@ -70,7 +72,10 @@ public class FedoraPolicyFinderModuleTest {
     private SessionFactory mockSessionFactory;
 
     @Mock
-    private Session mockSession;
+    private FedoraSessionImpl mockSession;
+
+    @Mock
+    private Session mockJcrSession;
 
     @Mock
     private Node mockNode, mockParentNode, mockPolicyNode;
@@ -115,19 +120,20 @@ public class FedoraPolicyFinderModuleTest {
         when(context.getResourceId()).thenReturn(mockResourceId);
 
         when(mockSessionFactory.getInternalSession()).thenReturn(mockSession);
-        when(mockSession.getNode(anyString())).thenReturn(mockNode);
+        when(mockSession.getJcrSession()).thenReturn(mockJcrSession);
+        when(mockJcrSession.getNode(anyString())).thenReturn(mockNode);
 
         when(mockNode.getParent()).thenReturn(mockParentNode);
 
         when(mockPolicyProperty.getNode()).thenReturn(mockPolicyNode);
 
-        when(mockNodeService.find(any(Session.class), anyString())).thenReturn(mockResource);
+        when(mockNodeService.find(any(FedoraSession.class), anyString())).thenReturn(mockResource);
         when(mockResource.hasType(FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION)).thenReturn(true);
         when(mockResource.getDescribedResource()).thenReturn(mockBinary);
 
         when(mockResource.getNode()).thenReturn(mockNode);
         when(mockNode.getPath()).thenReturn("/{}myPath");
-        when(mockBinaryService.findOrCreate(any(Session.class), anyString())).thenReturn(mockBinary);
+        when(mockBinaryService.findOrCreate(any(FedoraSession.class), anyString())).thenReturn(mockBinary);
 
         finderModule = new FedoraPolicyFinderModule();
         setField(finderModule, "sessionFactory", mockSessionFactory);

--- a/src/test/java/org/fcrepo/auth/xacml/FedoraResourceFinderModuleTest.java
+++ b/src/test/java/org/fcrepo/auth/xacml/FedoraResourceFinderModuleTest.java
@@ -21,11 +21,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Set;
 
@@ -36,6 +37,7 @@ import javax.jcr.Session;
 import javax.jcr.nodetype.NodeType;
 
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 
 import org.jboss.security.xacml.sunxacml.attr.AttributeValue;
 import org.jboss.security.xacml.sunxacml.finder.ResourceFinderResult;
@@ -46,29 +48,27 @@ import org.jboss.security.xacml.sunxacml.finder.ResourceFinderResult;
  *         Date: 5/9/14
  * @author Esme Cowles
  */
+@RunWith(MockitoJUnitRunner.class)
 public class FedoraResourceFinderModuleTest {
     FedoraResourceFinderModule resourceFinder;
 
     @Mock SessionFactory mockSessionFactory;
-    @Mock Session mockSession;
+    @Mock FedoraSessionImpl mockSession;
+    @Mock Session mockJcrSession;
     @Mock AttributeValue mockParent;
-    @Mock Node mockParentNode;
+    @Mock Node mockParentNode, mockChildNode, mockGrandchildNode;
     @Mock NodeType mockNodeType;
-    @Mock Node mockChildNode;
-    @Mock Node mockGrandchildNode;
-    @Mock NodeIterator mockParentIterator;
-    @Mock NodeIterator mockChildIterator;
-    @Mock NodeIterator mockGrandchildIterator;
+    @Mock NodeIterator mockParentIterator, mockChildIterator, mockGrandchildIterator;
 
     @Before
     public void setUp() throws RepositoryException {
-        initMocks(this);
         resourceFinder = new FedoraResourceFinderModule();
         resourceFinder.sessionFactory = mockSessionFactory;
 
         when( mockSessionFactory.getInternalSession() ).thenReturn(mockSession);
+        when( mockSession.getJcrSession() ).thenReturn(mockJcrSession);
         when( mockParent.getValue() ).thenReturn("/foo");
-        when( mockSession.getNode("/foo") ).thenReturn(mockParentNode);
+        when( mockJcrSession.getNode("/foo") ).thenReturn(mockParentNode);
 
         when( mockParentNode.getNodes() ).thenReturn(mockParentIterator);
         when( mockParentIterator.hasNext() ).thenReturn(true,false);

--- a/src/test/java/org/fcrepo/auth/xacml/TripleAttributeFinderModuleTest.java
+++ b/src/test/java/org/fcrepo/auth/xacml/TripleAttributeFinderModuleTest.java
@@ -29,19 +29,18 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.net.URI;
 import java.util.Set;
 
-import javax.jcr.Session;
-
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.FedoraSession;
+import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.services.NodeService;
-import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 
 import org.jboss.security.xacml.sunxacml.EvaluationCtx;
 import org.jboss.security.xacml.sunxacml.attr.AttributeValue;
@@ -50,8 +49,10 @@ import org.jboss.security.xacml.sunxacml.cond.EvaluationResult;
 import org.jboss.security.xacml.sunxacml.ctx.Status;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
@@ -63,6 +64,7 @@ import org.apache.jena.rdf.model.Resource;
  * @author Andrew Woods
  * @author Scott Prater
  */
+@RunWith(MockitoJUnitRunner.class)
 public class TripleAttributeFinderModuleTest {
 
     private TripleAttributeFinderModule finder;
@@ -71,7 +73,7 @@ public class TripleAttributeFinderModuleTest {
     private SessionFactory mockSessionFactory;
 
     @Mock
-    private Session mockSession;
+    private FedoraSessionImpl mockSession;
 
     @Mock
     private NodeService mockNodeService;
@@ -100,8 +102,6 @@ public class TripleAttributeFinderModuleTest {
 
     @Before
     public void setUp() {
-        initMocks(this);
-
         finder = new TripleAttributeFinderModule();
         finder.sessionFactory = mockSessionFactory;
         finder.nodeService = mockNodeService;
@@ -250,7 +250,7 @@ public class TripleAttributeFinderModuleTest {
         final ArgumentCaptor<String> propResourceId = ArgumentCaptor.forClass(String.class);
 
         doFindAttribute(resourceId, actions);
-        verify(mockNodeService).find(any(Session.class), propResourceId.capture());
+        verify(mockNodeService).find(any(FedoraSession.class), propResourceId.capture());
         assertEquals("/{ns}path/{ns}to/{ns}node", propResourceId.getValue());
     }
 
@@ -262,7 +262,7 @@ public class TripleAttributeFinderModuleTest {
         final ArgumentCaptor<String> propResourceId = ArgumentCaptor.forClass(String.class);
 
         doFindAttribute(resourceId, actions);
-        verify(mockNodeService).find(any(Session.class), propResourceId.capture());
+        verify(mockNodeService).find(any(FedoraSession.class), propResourceId.capture());
         assertEquals("/{ns}path/{ns}to/{ns}node", propResourceId.getValue());
     }
 
@@ -274,7 +274,7 @@ public class TripleAttributeFinderModuleTest {
         final ArgumentCaptor<String> propResourceId = ArgumentCaptor.forClass(String.class);
 
         doFindAttribute(resourceId, actions);
-        verify(mockNodeService).find(any(Session.class), propResourceId.capture());
+        verify(mockNodeService).find(any(FedoraSession.class), propResourceId.capture());
         assertEquals("/", propResourceId.getValue());
     }
 
@@ -286,7 +286,7 @@ public class TripleAttributeFinderModuleTest {
         final ArgumentCaptor<String> propResourceId = ArgumentCaptor.forClass(String.class);
 
         doFindAttribute(resourceId, actions);
-        verify(mockNodeService).find(any(Session.class), propResourceId.capture());
+        verify(mockNodeService).find(any(FedoraSession.class), propResourceId.capture());
         assertEquals("/", propResourceId.getValue());
     }
 

--- a/src/test/java/org/fcrepo/auth/xacml/XACMLWorkspaceInitializerTest.java
+++ b/src/test/java/org/fcrepo/auth/xacml/XACMLWorkspaceInitializerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
 
@@ -38,9 +37,12 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.services.BinaryService;
+import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 /**
  * <p>
@@ -49,6 +51,7 @@ import org.mockito.Mock;
  *
  * @author mohideen
  */
+@RunWith(MockitoJUnitRunner.class)
 public class XACMLWorkspaceInitializerTest {
 
     private XACMLWorkspaceInitializer xacmlWI;
@@ -57,7 +60,10 @@ public class XACMLWorkspaceInitializerTest {
     private SessionFactory mockSessionFactory;
 
     @Mock
-    private Session mockSession;
+    private Session mockJcrSession;
+
+    @Mock
+    private FedoraSessionImpl mockSession;
 
     @Mock
     private Node mockNode;
@@ -73,10 +79,9 @@ public class XACMLWorkspaceInitializerTest {
 
     @Before
     public void setUp() throws Exception {
-        initMocks(this);
-
         when(mockSessionFactory.getInternalSession()).thenReturn(mockSession);
-        when(mockSession.getRootNode()).thenReturn(mockNode);
+        when(mockSession.getJcrSession()).thenReturn(mockJcrSession);
+        when(mockJcrSession.getRootNode()).thenReturn(mockNode);
         when(mockBinaryService.findOrCreate(eq(mockSession), anyString())).thenReturn(mockBinary);
         when(mockNonRdfSourceDescription.getPath()).thenReturn("/dummy/test/path");
 
@@ -140,7 +145,7 @@ public class XACMLWorkspaceInitializerTest {
     @Test(expected = Error.class)
     public void testInitLinkRootToPolicyException() throws Exception {
         when(mockBinaryService.findOrCreate(eq(mockSession), anyString())).thenReturn(mockBinary);
-        when(mockSession.getRootNode()).thenThrow(new RepositoryException("expected"));
+        when(mockJcrSession.getRootNode()).thenThrow(new RepositoryException("expected"));
 
         xacmlWI.init();
     }


### PR DESCRIPTION
Addresses: https://jira.duraspace.org/browse/FCREPO-1868

Depends on https://github.com/fcrepo4/fcrepo4/pull/1123